### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -112,7 +112,7 @@ jobs:
           git checkout --progress --force refs/tags/${{ github.event.inputs.version }}
 
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
 
       - name: 'Set up Java'
         uses: actions/setup-java@v4


### PR DESCRIPTION
This reverts commit 65f5777fe50ea4b0fb2705fdffcad02d9b2c78b0.

See https://github.com/actions/upload-artifact/issues/478