### PR TITLE
Add option to set locale for Splunk and change default to en-GB

### DIFF
--- a/splunk-plugin/src/main/kotlin/io/rabobank/ret/splunk/plugin/SplunkCommand.kt
+++ b/splunk-plugin/src/main/kotlin/io/rabobank/ret/splunk/plugin/SplunkCommand.kt
@@ -59,7 +59,9 @@ class SplunkCommand(
     )
     var queryParts: List<String> = emptyList()
 
-    private val splunkUrl by lazy { "${splunkConfig.config.baseUrl}/en-US/app/${splunkConfig.config.app}/search" }
+    private val splunkUrl by lazy {
+        "${splunkConfig.config.baseUrl}/${splunkConfig.config.locale}/app/${splunkConfig.config.app}/search"
+    }
 
     override fun run() {
         val queryArguments = mutableListOf<String?>()

--- a/splunk-plugin/src/main/kotlin/io/rabobank/ret/splunk/plugin/splunk/SplunkPluginConfig.kt
+++ b/splunk-plugin/src/main/kotlin/io/rabobank/ret/splunk/plugin/splunk/SplunkPluginConfig.kt
@@ -21,12 +21,12 @@ class SplunkPluginConfig : Configurable() {
         listOf(
             ConfigurationProperty(
                 BASE_URL,
-                "Enter the Splunk base URL (<base-url> in <base-url>/en-US/app/<app-name>/search)",
+                "Enter the Splunk base URL (<base-url> in <base-url>/<locale>/app/<app-name>/search)",
                 required = true,
             ),
             ConfigurationProperty(
                 APP,
-                "Enter your Splunk app name (<app-name> in <base-url>/en-US/app/<app-name>/search)",
+                "Enter your Splunk app name (<app-name> in <base-url>/<locale>/app/<app-name>/search)",
                 required = true,
             ),
             ConfigurationProperty(
@@ -56,6 +56,7 @@ class SplunkPluginConfig : Configurable() {
 data class SplunkConfig(
     @JsonProperty("base_url")
     val baseUrl: String?,
+    val locale: String? = "en-GB",
     val app: String?,
     @JsonDeserialize(using = CommaDelimitedToListDeserializer::class)
     val indexes: List<String> = emptyList(),

--- a/splunk-plugin/src/test/kotlin/io/rabobank/ret/splunk/plugin/SplunkCommandTest.kt
+++ b/splunk-plugin/src/test/kotlin/io/rabobank/ret/splunk/plugin/SplunkCommandTest.kt
@@ -48,8 +48,7 @@ class SplunkCommandTest {
                 "base_url" to "splunk.base.url",
                 "app" to "general",
             )
-        val objectMapper = jacksonObjectMapper()
-        objectMapper.writeValue(mockedOsUtils.getPluginConfig("splunk").toFile(), splunkConfig)
+        jacksonObjectMapper.writeValue(mockedOsUtils.getPluginConfig("splunk").toFile(), splunkConfig)
 
         val splunkCommand =
             SplunkCommand(
@@ -57,7 +56,7 @@ class SplunkCommandTest {
                 mockedRetContext,
                 SplunkPluginConfig().apply {
                     pluginName = "splunk"
-                    this.objectMapper = objectMapper
+                    objectMapper = jacksonObjectMapper
                     osUtils = mockedOsUtils
                     retConfig = mock()
                 },
@@ -166,8 +165,28 @@ class SplunkCommandTest {
         verify(mockedBrowserUtils).openUrl(expectedURL)
     }
 
+    @Test
+    fun `should set locale`() {
+        val splunkConfig =
+            mapOf(
+                "base_url" to "splunk.base.url",
+                "app" to "general",
+                "locale" to "en-US",
+            )
+        jacksonObjectMapper.writeValue(mockedOsUtils.getPluginConfig("splunk").toFile(), splunkConfig)
+        val project = "my-application"
+
+        val expectedURL = "splunk.base.url/en-US/app/general/search?q=search+project%3D$project"
+
+        val exitCode = commandLine.execute("--project", project)
+        assertThat(exitCode).isEqualTo(0)
+
+        verify(mockedBrowserUtils).openUrl(expectedURL)
+    }
+
     private companion object {
-        private const val SPLUNK_URL = "splunk.base.url/en-US/app/general/search"
+        private const val SPLUNK_URL = "splunk.base.url/en-GB/app/general/search"
+        private val jacksonObjectMapper = jacksonObjectMapper()
     }
 }
 


### PR DESCRIPTION
`en-GB` makes it use a 24 hour time format, which is what we prefer